### PR TITLE
Feature: Enable export of Sentinel-2 reflectance & radiance products for 10m data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ gips_creds.sh.enc
 ortho
 sixs
 docker/acolite_py_linux/
+# vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/gips/data/sentinel2/sentinel2.py
+++ b/gips/data/sentinel2/sentinel2.py
@@ -248,7 +248,7 @@ class sentinel2Asset(gips.data.core.CloudCoverAsset,
     }
 
     # default resultant resolution for resampling during to Data().copy()
-    _defaultresolution = (10, 10)
+    _defaultresolution = (20, 20)
 
     def __init__(self, filename):
         """Inspect a single file and set some metadata.

--- a/gips/data/sentinel2/sentinel2.py
+++ b/gips/data/sentinel2/sentinel2.py
@@ -869,7 +869,7 @@ class sentinel2Data(gips.data.core.CloudCoverData):
                       for band_name in _band_names_10m]
         },
         'ref-10m': {
-            'description': 'Surface-leaving radiance (10m)',
+            'description': 'Surface reflectance (10m)',
             'assets': _asset_types,
             'bands': [{'name': band_name, 'units': Data._unitless}
                       for band_name in _band_names_10m]


### PR DESCRIPTION
This PR modifies the Sentinel-2 driver to enable us to export reflectance/radiance products at the native 10m spatial resolution of the blue/green/red/NIR bands.

The driver gets 2 new products to the list of "Standard Products" (`ref@10m` & `rad@10m`), which trigger passing `spatial_res=10` to product generation methods (`ref_toa_geoimage`, `rad_toa_geoimage`, `rad_geoimage` & `ref_geoimage`). If `ref_toa_geoimage` is given a `spatial_res` argument, and if this argument is not the default resolution (20m), a subset of bands are selected for export to VRT. The subsequent methods in the work plan follow along by loading the appropriate (10m) version of the previous step.

Outputs get tagged with the new product name and can co-exist with the default 20m versions. For example, asking for products `ref` and `ref@10m` output:
```
2018195_S2A_ref.tif
2018195_S2A_ref@10m.tif
```

I haven't integrated the option to output 10m data with generation indices (we do this in sturdy-octopus so it's not needed for us), but it seems doable to check for a suffix when indices are requested, similar to what is done with toa/ref indices. I'm also not quite sure how testing is done for GIPS drivers, but am happy to follow suggestions.

Finally I changed the `_defaultresolution` property from `(10, 10)` to `(20, 20)`, which is used in `Asset.copy` if a resolution is not provided. It's also now used inside the S2 driver to check if it's asked to generate the 10m data. Changing to 20 seems more in line with the existing behavior, which was to create a VRT at 20m, but I'm not quite sure what `_defaultresolution` is used for so would appreciate attention to this change.