### PR TITLE
fix: update locations of rios/python-fmask since bitbucket->github move

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,8 @@ setup(
         'pydap==3.2',
         'pysolar==0.6',
         'dbfread==2.0.7',
-        'rios @ https://bitbucket.org/chchrsc/rios/downloads/rios-1.4.3.zip#egg=rios-1.4.3',
-        'python-fmask @ https://bitbucket.org/chchrsc/python-fmask/downloads/python-fmask-0.5.0.zip#egg=python-fmask-0.5.0',
+        'rios @ https://github.com/ubarsc/rios/archive/rios-1.4.3.zip#egg=rios-rios-1.4.3#subdirectory=rios',
+        'python-fmask @ https://github.com/ubarsc/python-fmask/archive/pythonfmask-0.5.0.zip#egg=python-fmask-0.5.0',
         'usgs', # 0.2.1 known to work
         'backports.functools_lru_cache',
         'backoff',


### PR DESCRIPTION
Sources for rios and python-fmask were migrated to Github. This PR updates their locations in GIPS setup.py

Actions after this PR is merged,

* Bump version tag & release on this repo (manually)
* Upload new release to our public S3 artifact vault so we can install it more quickly during Docker builds